### PR TITLE
fix: 解决 stopLocation() 后 listenLocation() 的重复调用

### DIFF
--- a/lib/src/dart/amap_location.dart
+++ b/lib/src/dart/amap_location.dart
@@ -252,8 +252,6 @@ class AmapLocation {
         _locationController?.close();
         _locationController = null;
 
-        _androidLocationDelegate = null;
-
         await _androidClient?.stopLocation();
       },
       ios: (pool) async {


### PR DESCRIPTION
由于在 listenLocation() 方法中存在 _androidLocationDelegate == null 的判断，导致调用 stopLocation 后，会重新申请一个 delegate 并将其设置为 listener。为了不重复调用，将 _androidLocationDelegate 去掉。